### PR TITLE
store images with the appropriate extension:

### DIFF
--- a/giraffe.py
+++ b/giraffe.py
@@ -83,15 +83,28 @@ def image_route(path):
     args = get_image_args(request.args)
     params = args.values()
     if params:
-        stuff = [base,]
-        stuff.extend(args.values())
-        filename_with_args = "_".join(str(x) for x in stuff
-                                   if x is not None) + "." + ext
-        # if we enable compression we may want to modify the filename here to include *.gz
-        param_name = os.path.join(CACHE_DIR, dirname, filename_with_args)
+        param_name = calculate_new_path(dirname, base, ext, args)
         return get_file_with_params_or_404(bucket, path, param_name, args)
     else:
         return get_file_or_404(bucket, path)
+
+
+def calculate_new_path(dirname, base, ext, args):
+    stuff = [base,]
+    stuff.extend(args[key] for key in args if key != 'fm')
+ 
+    format = args.get('fm')
+    if format:
+        if format == 'png':
+            ext = 'png'
+        if format == 'jpg' or format == 'jpeg':
+            ext = 'jpg'
+
+    filename_with_args = "_".join(str(x) for x in stuff
+                               if x is not None) + "." + ext
+    # if we enable compression we may want to modify the filename here to include *.gz
+    param_name = os.path.join(CACHE_DIR, dirname, filename_with_args)
+    return param_name
 
 
 def positive_int_or_none(value):

--- a/test_giraffe.py
+++ b/test_giraffe.py
@@ -320,6 +320,9 @@ class TestImageRoute(FlaskTestCase):
         self.assertEqual(r.status_code, 200)
         content_type = r.headers.get("content-type")
         self.assertEqual(content_type, "image/png")
+        args, kwargs = s3.upload.call_args
+        self.assertEqual(args[0], "giraffe/redbull.png")
+        self.assertEqual(kwargs['content_type'], "image/png")
         self.assertEqual(Image(blob=r.data).format, 'PNG')
 
     @mock.patch('giraffe.s3')
@@ -381,6 +384,9 @@ class TestImageRoute(FlaskTestCase):
         self.assertEqual(r.status_code, 200)
         content_type = r.headers.get("content-type")
         self.assertEqual(content_type, "image/jpeg")
+        args, kwargs = s3.upload.call_args
+        self.assertEqual(args[0], "giraffe/redbull.jpg")
+        self.assertEqual(kwargs['content_type'], "image/jpeg")
         self.assertEqual(Image(blob=r.data).format, 'JPEG')
 
     @mock.patch('giraffe.s3')


### PR DESCRIPTION
Instead of redbull.jpg?fm=png generating an image named
giraffe/redbull_png.jpg in S3 we'll now generate giraffe/redbull.png.
