### PR TITLE
Remove dogpile caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ MarkupSafe==0.18
 Pillow==2.4.0
 Wand==0.3.7
 Werkzeug==0.9.4
-dogpile.core==0.4.1
-dogpile.cache==0.5.2
 flexmock==0.9.7
 futures==2.1.5
 gevent==1.0.1

--- a/test_giraffe.py
+++ b/test_giraffe.py
@@ -348,16 +348,6 @@ class TestImageRoute(FlaskTestCase):
         with Color('red') as bg:
             self.image = Image(width=1920, height=1080, background=bg)
 
-        # let's clear the cache
-        params = OrderedDict()
-        params['w'] = 100
-        params['h'] = 100
-        giraffe.get_file_or_404.invalidate(self.bucket, "redbull.jpg")
-        giraffe.get_file_with_params_or_404.invalidate(self.bucket,
-                                                       "redbull.jpg",
-                                                       "{}/redbull_w100_h100.jpg".format(giraffe.CACHE_DIR),
-                                                       params,
-                                                       False)
 
     @mock.patch('giraffe.s3')
     def test_image_doesnt_exist(self, s3):
@@ -602,26 +592,6 @@ class TestOverlayRoutes(FlaskTestCase):
         super(TestOverlayRoutes, self).setUp()
         with Color('red') as bg:
             self.image = Image(width=1920, height=1080, background=bg)
-
-        # let's clear the cache
-        params = OrderedDict()
-        params['w'] = 100
-        params['h'] = 100
-        giraffe.get_file_or_404.invalidate(self.bucket, "art.png")
-        giraffe.get_file_with_params_or_404.invalidate(self.bucket,
-                                                       "art.png",
-                                                       "{}/art_w100_h100.jpg".format(giraffe.CACHE_DIR),
-                                                       params,
-                                                       False)
-        params = OrderedDict()
-        params['bg'] = '451D74'
-        params['overlay'] = '/wtf/tshirts/overlay.png'
-        giraffe.get_file_with_params_or_404.invalidate(
-            self.bucket,
-            "art.png",
-            '{}/art_overlayhttps://cloudfront.whatever.org/tshirts/overlay.png_bg451D74.png'.format(giraffe.CACHE_DIR),
-            params,
-            False)
 
     @mock.patch('giraffe.s3')
     def test_image_overlay_relative_url(self, s3):


### PR DESCRIPTION
First there were bugs with caching objects over 1MB, now there are bugs with
the in memory cache that never expires objects and boxes running out of
memory.

Given that Giraffe should be put behind a CDN like Cloudfront or Akamai (or
roll your own with Varnish) you should already have a super cache at the HTTP
level and caching internal objects and stuff is likely not necessary.
